### PR TITLE
fix: rollback snapshot to prevent bolt deadlock

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -331,7 +331,8 @@ func (o *snapshotter) commit(ctx context.Context, isRemote bool, name, key strin
 	}
 
 	if !isRemote { // skip diskusage for remote snapshots for allowing lazy preparation of nodes
-		du, err := fs.DiskUsage(ctx, o.upperPath(id))
+		var du fs.Usage
+		du, err = fs.DiskUsage(ctx, o.upperPath(id))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Chris Goller <goller@gmail.com>